### PR TITLE
Added example MYSQL framework with backup and restore tasks

### DIFF
--- a/config/samples/mysql.yaml
+++ b/config/samples/mysql.yaml
@@ -103,6 +103,19 @@ spec:
               volumeMounts:
               - name: mysql-persistent-storage
                 mountPath: /var/lib/mysql
+              livenessProbe:
+                exec:
+                  command: ["mysqladmin", "-p{{PASSWORD}}", "ping"]
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                timeoutSeconds: 5
+              readinessProbe:
+                exec:
+                  # Check we can execute queries over TCP (skip-networking is off).
+                  command: ["mysql", "-p{{PASSWORD}}", "-h", "127.0.0.1", "-e", "SELECT 1"]
+                initialDelaySeconds: 5
+                periodSeconds: 2
+                timeoutSeconds: 1
             volumes:
             - name: mysql-persistent-storage
               persistentVolumeClaim:

--- a/config/samples/mysql.yaml
+++ b/config/samples/mysql.yaml
@@ -1,0 +1,244 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Framework
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: mysql
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: mysql-57
+  namespace: default
+spec:
+  serviceSpec:
+  version: "5.7"
+  connectionString: ""
+  framework:
+    name: mysql
+    kind: Framework
+  parameters:
+  - name: BACKUP_FILE
+    description: "Filename to save the backups to"
+    default: "backup.sql"
+    displayName: "BackupFile"
+  - name: PASSWORD
+    default: "password"
+  tasks:
+    deploy:
+      resources:
+      - mysql.yaml
+    init:
+      resources:
+      - init.yaml
+    backup:
+      resources:
+      - backup-pv.yaml
+      - backup.yaml
+    restore:
+      resources:
+      - restore.yaml
+    load-data:
+      resources:
+      - job.yaml
+    clear-data:
+      resources:
+      - job.yaml
+    query:
+      resources:
+      - job.yaml
+  templates:
+    mysql.yaml: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: mysql
+      spec:
+        ports:
+        - port: 3306
+        selector:
+          app: mysql
+        clusterIP: None
+      ---
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: mysql-pv
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      ---
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mysql
+      spec:
+        selector:
+          matchLabels:
+            app: mysql
+        strategy:
+          type: Recreate
+        template:
+          metadata:
+            labels:
+              app: mysql
+          spec:
+            containers:
+            - image: mysql:5.7
+              name: mysql
+              env:
+                # Use secret in real usage
+              - name: MYSQL_ROOT_PASSWORD
+                value: {{PASSWORD}}
+              - name: MYSQL_DATABASE
+                value: maestro
+              ports:
+              - containerPort: 3306
+                name: mysql
+              volumeMounts:
+              - name: mysql-persistent-storage
+                mountPath: /var/lib/mysql
+            volumes:
+            - name: mysql-persistent-storage
+              persistentVolumeClaim:
+                claimName: mysql-pv
+    backup-pv.yaml: |
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: backup-pv
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+    init.yaml: |
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: default
+        name: {{PLAN_NAME}}-job
+      spec:
+        template:
+          metadata:
+            name: {{PLAN_NAME}}-job
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - name: {{PLAN_NAME}}
+              image: mysql:5.7
+              imagePullPolicy: IfNotPresent
+              command:
+              - /bin/sh
+              - -c
+              - "mysql -u root -h {{NAME}}-mysql -p{{PASSWORD}} -e \"CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );\" maestro "       
+    backup.yaml: |
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: default
+        name: {{PLAN_NAME}}-job
+      spec:
+        template:
+          metadata:
+            name: {{PLAN_NAME}}-job
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - name: bb
+              image: mysql:5.7
+              imagePullPolicy: IfNotPresent
+              command:
+              - /bin/sh
+              - -c
+              - "mysqldump -u root -h {{NAME}}-mysql -p{{PASSWORD}} maestro > /backups/{{BACKUP_FILE}}"
+              volumeMounts:
+              - name: backup-pv
+                mountPath: /backups
+            volumes:
+            - name: backup-pv
+              persistentVolumeClaim:
+                claimName: backup-pv
+    restore.yaml: |
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: default
+        name: {{PLAN_NAME}}-job
+      spec:
+        template:
+          metadata:
+            name: {{PLAN_NAME}}-job
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - name: {{PLAN_NAME}}
+              image: mysql:5.7
+              imagePullPolicy: IfNotPresent
+              command:
+              - /bin/sh
+              - -c
+              - "mysql -u root -h {{NAME}}-mysql -p{{PASSWORD}} --database=maestro < /backups/{{BACKUP_FILE}}"
+              volumeMounts:
+              - name: backup-pv
+                mountPath: /backups
+            volumes:
+            - name: backup-pv
+              persistentVolumeClaim:
+                claimName: {{NAME}}-backup-pv
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: deploy
+          strategy: serial
+          steps:
+            - name: deploy
+              tasks:
+              - deploy
+            - name: init
+              tasks:
+              - init
+    backup:
+      strategy: serial
+      phases:
+        - name: backup
+          strategy: serial
+          steps:
+            - name: backup
+              tasks:
+              - backup
+    restore:
+      strategy: serial
+      phases:
+        - name: restore
+          strategy: serial
+          steps:
+            - name: restore
+              tasks:
+              - restore
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    framework: mysql
+  name: mysql
+spec:
+  frameworkVersion:
+    name: mysql-57
+    namespace: default
+    type: FrameworkVersions
+  # Add fields here
+  parameters:
+    PASSWORD: password
+
+
+

--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -1,0 +1,84 @@
+# Backup Jobs   
+
+Maestro has the ability to capture the backup and restoration process for database applications.  
+
+## MySQL
+
+Create an instance of MySQL using the provded Framework
+
+```bash
+$ kubectl apply -f samples/config/mysql.yaml
+framework.maestro.k8s.io/mysql created
+frameworkversion.maestro.k8s.io/mysql-57 created
+instance.maestro.k8s.io/mysql created
+```
+
+Query the database to show
+```bash
+MYSQL_POD=`kubectl get pods -l app=mysql,step=deploy -o jsonpath="{.items[*].metadata.name}"`
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "show tables;" maestro
+```
+
+Add some data:
+```bash
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "INSERT INTO example ( id, name ) VALUES ( null, 'New Data' );" maestro
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "INSERT INTO example ( id, name ) VALUES ( null, 'New Data' );" maestro
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "INSERT INTO example ( id, name ) VALUES ( null, 'New Data' );" maestro
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "INSERT INTO example ( id, name ) VALUES ( null, 'New Data' );" maestro
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "select * from example;" maestro
+```
+
+
+## Take a backup
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  labels:
+    framework-version: mysql-57
+    instance: mysql
+  name: mysql-backup
+  namespace: default
+spec:
+  instance:
+    kind: Instance
+    name: mysql
+    namespace: default
+  planName: backup
+EOF
+```
+
+## Delete data from the datbase
+
+```bash
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "delete from example;" maestro
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "select * from example;" maestro
+```
+
+## Perform a restore
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  labels:
+    framework-version: mysql-57
+    instance: mysql
+  name: mysql-restore
+  namespace: default
+spec:
+  instance:
+    kind: Instance
+    name: mysql
+    namespace: default
+  planName: restore
+EOF
+```
+ And then query to see the data from before
+
+ ```bash
+kubectl exec -it $MYSQL_POD -- mysql -ppassword  -e "select * from example;" maestro
+ ```

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -238,7 +238,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 	//See if this has already been proceeded
 	if planExecution.Status.State == maestrov1alpha1.PhaseStateComplete {
 		log.Printf("PlanExecution %v has already run to completion, not processing.\n", planExecution.Name)
-    return reconcile.Result{}, nil
+		return reconcile.Result{}, nil
 	}
 
 	//Get Instance Object

--- a/pkg/util/health/ready.go
+++ b/pkg/util/health/ready.go
@@ -25,8 +25,12 @@ func IsHealthy(c client.Client, obj runtime.Object) error {
 		return fmt.Errorf("Ready Replicas (%v) does not equal Requested Replicas (%v)", ss.Status.ReadyReplicas, ss.Status.Replicas)
 	case *appsv1.Deployment:
 		d := obj.(*appsv1.Deployment)
-		log.Printf("Deployment %v is marked healthy\n", d.Name)
-		return nil
+		if d.Spec.Replicas != nil && d.Status.ReadyReplicas == *d.Spec.Replicas {
+			log.Printf("Deployment %v is marked healthy\n", d.Name)
+			return nil
+		}
+		log.Printf("Deployment %v is NOT healthy.  Not enough ready replicas: %v/%v\n", d.Name, d.Status.ReadyReplicas, d.Spec.Replicas)
+		return fmt.Errorf("Ready Replicas (%v) does not equal Requested Replicas (%v)", d.Status.ReadyReplicas, d.Spec.Replicas)
 	case *batchv1.Job:
 		job := obj.(*batchv1.Job)
 		// job.Status.


### PR DESCRIPTION
This outlines an example application that defines how to backup and restore data within the application definition.

Could you guys please review for 
1) Working docs and how to run them.  Happy to expand where is interesting
2) Format of tasks.  Would like to convert this to use a base job.yaml spec with a patch that changes the command run in the job.
3) Is this the right app (Redis, kafka, zookeeper, etc)?