### PR TITLE
Added quick start video

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Maestro provides a declarative approach to building production-grade Kubernetes Operators covering the entire application lifecycle. 
 
+## Getting Started
+
+See the [Documentation](master/docs) with [Examples](config/samples).
+
+![Quick Start](docs/gif/quickstart-0.1.0.gif)
+
 ## Pre-requisites
 
 Before you get started:


### PR DESCRIPTION
For Documentation purposes I added:

- Added `Getting Started` section in `readme.md` to demonstrate `Zookeeper` and `Kafka` operators
- Created `docs/gif` and added the `quickstart-0.1.0.gif`