### PR TITLE
[WIP] Kubectl Maestro Plugin

### DIFF
--- a/cmd/kubectl-plugin/kubectl-maestro
+++ b/cmd/kubectl-plugin/kubectl-maestro
@@ -82,9 +82,9 @@ function deleteDependencies {
 }
 
 function compareArray {
-  awk 'BEGIN{RS=ORS=" "}
-       {NR==FNR?a[$0]++:a[$0]--}
-       END{for(k in a)if(a[k])print k}' <(echo -n "${!1}") <(echo -n "${!2}")
+    awk 'BEGIN{RS=ORS=" "}
+         {NR==FNR?a[$0]++:a[$0]--}
+         END{for(k in a)if(a[k])print k}' <(echo -n "${!1}") <(echo -n "${!2}")
 }
 
 function frameworkLookup {
@@ -193,7 +193,13 @@ then
     # checking dependencies
     echo "Checking for $2 dependencies..."
     eval dependency_list=('$'{$2_dependency_list[@]})
-    FRAMEWORKS_INSTALLED=$(kubectl get framework ${dependency_list[@]} -o jsonpath="{.items[*].metadata.name}")
+    if [[ ${#dependency_list[@]} -lt "2" ]]
+    then
+        jsonpath=".metadata.name"
+    else
+        jsonpath=".items[*].metadata.name"
+    fi
+    FRAMEWORKS_INSTALLED=$(kubectl get framework ${dependency_list[@]} -o jsonpath="{$jsonpath}")
     if [ -z "$FRAMEWORKS_INSTALLED" ]
     then
         echo "No dependency frameworks are installed."

--- a/cmd/kubectl-plugin/kubectl-maestro
+++ b/cmd/kubectl-plugin/kubectl-maestro
@@ -335,7 +335,7 @@ then
     fi
 fi
 
-function createFunction {
+function createInstance {
     framework=$2
     shift 2
     while getopts ":n:v:p:" opt ; do
@@ -344,11 +344,9 @@ function createFunction {
                 c+=("$OPTARG")
                 ;;
                 n)
-                echo "name is: $OPTARG"
                 name=$OPTARG
                 ;;
                 v)
-                echo "version is: $OPTARG"
                 frameworkversion=$OPTARG
                 ;;                
                 \?)
@@ -393,7 +391,7 @@ EOF
 # create argument handling
 if [[ "$1" == "create" ]]
 then
-    createFunction "$@"
+    createInstance "$@"
     if [[ "$?" == "1" ]]
     then
         echo ""
@@ -401,7 +399,7 @@ then
         echo ""
         echo "Invalid create command."
         echo ""
-        echo "Syntax: kubectl maestro create -n <instanceName> -v <versionNumber> -p PARAM1=VALUE -p PARAM2=Value"
+        echo "Syntax: kubectl maestro create <framework> -n <instanceName> -v <versionNumber> -p PARAM1=VALUE -p PARAM2=Value"
         echo ""
         echo "Example: kubectl maestro create kafka -n kafka -v 2.11-2.4.0 -p KAFKA_ZOOKEEPER_URI:zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 -p KAFKA_ZOOKEEPER_PATH:\"/small\" -p BROKERS_COUNT:\"3\""
         exit 1
@@ -443,6 +441,66 @@ then
         echo "Example: kubectl maestro scale kafka --replicas=1"
         exit 1
         fi
+    fi
+    exit 0
+fi
+
+function startPlan {
+    shift 1
+    while getopts ":n:v:p:" opt ; do
+        case "$opt" in
+                p)   
+                planName=$OPTARG
+                ;;
+                n)
+                name=$OPTARG
+                ;;
+                v)
+                frameworkversion=$OPTARG
+                ;;                
+                \?)
+                echo "Invalid option: -$OPTARG" >&2
+                exit 1
+                ;;
+                :)
+                echo "Option -$OPTARG requires an argument." >&2
+                exit 1
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+    cat <<EOF | kubectl apply -f -
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+    labels:
+        framework-version: $frameworkversion
+        instance: $name
+    name: $name
+spec:
+    instance:
+        kind: Instance
+        name: $name
+        namespace: default
+    planName: $planName
+EOF
+}
+
+# create argument handling
+if [[ "$1" == "start" ]]
+then
+    startPlan "$@"
+    if [[ "$?" == "1" ]]
+    then
+        echo ""
+        echo "Failed to create instance for framework $framework."
+        echo ""
+        echo "Invalid create command."
+        echo ""
+        echo "Syntax: kubectl maestro start -n <instanceName> -v <version> -p <planName>"
+        echo ""
+        echo "Example: kubectl maestro start -n demo -v flink-financial-demo -p upload"
+        exit 1
     fi
     exit 0
 fi

--- a/cmd/kubectl-plugin/kubectl-maestro
+++ b/cmd/kubectl-plugin/kubectl-maestro
@@ -276,7 +276,7 @@ if [[ "$1" == "shell" ]]
 then
     if [[ "$2" == "flink" ]]
     then
-        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=demo-flink-jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
         if [ -z "$JOBMANAGER_POD" ]
         then
             echo "No running jobmanager found."
@@ -301,7 +301,7 @@ then
     if [[ "$2" == "flink" ]]
     then
         # Get current running jobmanager
-        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=demo-flink-jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
         if [ -z "$JOBMANAGER_POD" ]
         then
             echo "No running jobmanager found."
@@ -324,7 +324,7 @@ fi
 if [[ "$1" == "flink" ]]
 then
     # Get current running jobmanager
-    JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+    JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=demo-flink-jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
     if [ -z "$JOBMANAGER_POD" ]
     then
         echo "No running jobmanager found."

--- a/cmd/kubectl-plugin/kubectl-maestro
+++ b/cmd/kubectl-plugin/kubectl-maestro
@@ -330,7 +330,7 @@ then
         echo "No running jobmanager found."
         exit 1
     else
-        kubectl exec -it $JOBMANAGER_POD -- bin/flink ${@:2}
+        kubectl exec -it $JOBMANAGER_POD -- bin/flink ${@:2} -m localhost:8081
         exit 0
     fi
 fi

--- a/cmd/kubectl-plugin/kubectl-maestro
+++ b/cmd/kubectl-plugin/kubectl-maestro
@@ -1,0 +1,453 @@
+#!/bin/bash
+
+flink_dependency_list=("")
+kafka_dependency_list=("zookeeper")
+zookeeper_dependency_list=("")
+
+
+# optional argument handling
+if [[ "$1" == "version" ]]
+then
+    echo "0.0.1"
+    exit 0
+fi
+
+function frameworkInstall {
+    if [[ "$1" == "" ]]
+    then
+        echo "Cannot install empty framework."
+        exit 1
+    else
+        echo "Installing $1 framework..."
+        kubectl apply -f https://raw.githubusercontent.com/maestrosdk/frameworks/master/repo/$2/$1/versions/$3/$1-framework.yaml
+        kubectl apply -f https://raw.githubusercontent.com/maestrosdk/frameworks/master/repo/$2/$1/versions/$3/$1-frameworkversion.yaml
+        if [[ "$?" == "1" ]]
+        then
+            echo "Failed to install framework $1"
+            exit 1
+        fi
+        echo "$2 framework $1 successfully installed."
+    fi
+}
+
+function frameworkUninstall {
+    if [[ "$1" == "" ]]
+    then
+        echo "Cannot uninstall empty framework."
+        exit 1
+    else
+        echo "Uninstalling $1 framework..."
+        kubectl delete -f https://raw.githubusercontent.com/maestrosdk/frameworks/master/repo/$2/$1/versions/$3/$1-framework.yaml
+        if [[ "$?" == "1" ]]
+        then
+            echo "Failed to uninstall framework $1"
+            exit 1
+        fi
+        kubectl delete -f https://raw.githubusercontent.com/maestrosdk/frameworks/master/repo/$2/$1/versions/$3/$1-frameworkversion.yaml
+        if [[ "$?" == "1" ]]
+        then
+            echo "Failed to uninstall frameworkversion $1"
+            exit 1
+        fi
+        echo "$2 framework $1 successfully uninstalled."
+    fi
+}
+
+function deleteDependencies {
+    # checking dependencies
+    echo "Checking for $1 dependencies..."
+    # copying from the right array
+    eval dependency_list=('$'{$1_dependency_list[@]})
+    # adjusting the kubectl command for the case of a single dependency
+    if [[ ${#dependency_list[@]} -lt "2" ]]
+    then
+        jsonpath=".metadata.name"
+    else
+        jsonpath=".items[*].metadata.name"
+    fi
+    FRAMEWORKS_INSTALLED=$(kubectl get framework ${dependency_list[@]} -o jsonpath="{$jsonpath}")
+    if [ -z "$FRAMEWORKS_INSTALLED" ]
+    then
+        echo "Dependency frameworks are uninstalled."
+        frameworkLookup uninstall $1
+    else
+        echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
+        for i in "${dependency_list[@]}"
+        do
+        frameworkLookup uninstall $i
+        done
+        echo "All dependency frameworks are uninstalled now."
+        frameworkLookup uninstall $1
+    fi
+}
+
+function compareArray {
+  awk 'BEGIN{RS=ORS=" "}
+       {NR==FNR?a[$0]++:a[$0]--}
+       END{for(k in a)if(a[k])print k}' <(echo -n "${!1}") <(echo -n "${!2}")
+}
+
+function frameworkLookup {
+    githubCredentials=$(cat ~/.git-credentials | cut -d'@' -f 1 | sed 's/https:\/\///')
+    if [[ "$1" == "install" ]]
+    then
+        # Install part
+        echo "Looking up stable version of $2"
+        version="stable"
+        frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/stable/$2/versions | jq -r ".[] | .name ")
+        if [[ $frameworkVersions == "" ]]
+        then
+            echo "Stable version of $2 not found. Looking up incubating versions..."
+            frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/incubating/$2/versions | jq -r ".[] | .name ")
+            if [[ $frameworkVersions == "" ]]
+            then
+                echo -e "\tFramework $2 not found in registry."
+                exit 1
+            fi
+            version="incubating"
+        fi
+        if [[ ${#frameworkVersions[@]} -lt 2 ]]
+        then
+            echo -e "\tFound ${#frameworkVersions[@]} $version version"
+            latestVersion=$(printf "%s\n" ${frameworkVersions[@]} | sort -r )
+            echo "Found latest $version version $latestVersion"
+        else
+            echo -e "\tFound ${#frameworkVersions[@]} $version versions"
+            echo "Select latest $version version..."
+            reverseSortedVersions=$(printf "%s\n" ${frameworkVersions[@]} | sort -r )
+            latestVersion=(${reverseSortedVersions[0]})
+            echo -e "\tFound latest $version version $latestVersion"
+        fi
+        frameworkInstall $2 $version $latestVersion
+    elif [[ "$1" == "lookup" ]]
+    then
+        frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/stable/$2/versions | jq -r ".[] | .name ")
+        if [[ $frameworkVersions == "" ]]
+        then
+            echo "Stable version of $2 not found. Looking up incubating versions..."
+            frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/incubating/$2/versions | jq -r ".[] | .name ")
+            if [[ $frameworkVersions == "" ]]
+            then
+                echo -e "\tFramework $2 not found in registry."
+                echo ""
+                echo "Available stable frameworks to install:"
+                availableStable=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/stable | jq -r ".[] | .name ")
+                for f in ${availableStable[@]}; do
+                    echo -e "\t$f"
+                done
+                echo "Available incubating frameworks to install:"
+                availableIncubating=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/incubating | jq -r ".[] | .name ")
+                for f in ${availableIncubating[@]}; do
+                    echo -e "\t$f"
+                done
+                exit 1
+            fi
+        fi
+        echo "Framework $2 found in registry."
+    else
+        # Uninstall part
+        echo "Looking up stable version of $2"
+        version="stable"
+        frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/stable/$2/versions | jq -r ".[] | .name ")
+        if [[ $frameworkVersions == "" ]]
+        then
+            echo "Stable version of $2 not found. Looking up incubating versions..."
+            frameworkVersions=$(curl -s --user $githubCredentials https://api.github.com/repos/maestrosdk/frameworks/contents/repo/incubating/$2/versions | jq -r ".[] | .name ")
+            if [[ $frameworkVersions == "" ]]
+            then
+                echo -e "\tFramework $2 not found in registry."
+                exit 1
+            fi
+            version="incubating"
+        fi
+        if [[ ${#frameworkVersions[@]} -lt 2 ]]
+        then
+            echo -e "\tFound ${#frameworkVersions[@]} $version version"
+            latestVersion=$(printf "%s\n" ${frameworkVersions[@]} | sort -r )
+            echo "Found latest $version version $latestVersion"
+        else
+            echo -e "\tFound ${#frameworkVersions[@]} $version versions"
+            echo "Select latest $version version..."
+            reverseSortedVersions=$(printf "%s\n" ${frameworkVersions[@]} | sort -r )
+            latestVersion=(${reverseSortedVersions[0]})
+            echo -e "\tFound latest $version version $latestVersion"
+        fi
+        frameworkUninstall $2 $version $latestVersion
+
+    fi    
+}
+
+# install argument handling
+if [[ "$1" == "install" ]]
+then
+    if ! [ -x "$(command -v jq)" ]; then
+        echo 'Error: jq is not installed.' >&2
+        exit 1
+    fi
+    if [[ "$2" == "" ]]
+    then
+        echo "Cannot install empty framework."
+        exit 1
+    fi
+    frameworkLookup lookup $2
+    # checking dependencies
+    echo "Checking for $2 dependencies..."
+    eval dependency_list=('$'{$2_dependency_list[@]})
+    FRAMEWORKS_INSTALLED=$(kubectl get framework ${dependency_list[@]} -o jsonpath="{.items[*].metadata.name}")
+    if [ -z "$FRAMEWORKS_INSTALLED" ]
+    then
+        echo "No dependency frameworks are installed."
+        ## now loop through the dependencies to install
+        for d in "${dependency_list[@]}"
+        do
+        frameworkLookup install $d
+        done
+        frameworkLookup install $2
+        exit 0
+    else
+        TO_INSTALL_FRAMEWORKS=($(compareArray dependency_list[@] FRAMEWORKS_INSTALLED[@]))
+        if [ -z "$TO_INSTALL_FRAMEWORKS" ]
+        then
+            echo "All dependency frameworks are installed."
+            frameworkLookup install $2
+        else
+            echo -e "Found missing framework(s):\n\t${TO_INSTALL_FRAMEWORKS[@]}"
+            for d in "${TO_INSTALL_FRAMEWORKS[@]}"
+            do
+            frameworkLookup install $d
+            done
+            echo "All dependency frameworks are installed now."
+            frameworkLookup install $2
+        fi
+    fi
+    exit 0
+fi
+
+# uninstall argument handling
+if [[ "$1" == "uninstall" ]]
+then
+    if ! [ -x "$(command -v jq)" ]; then
+        echo 'Error: jq is not installed.' >&2
+        exit 1
+    fi
+    # checking to see if framework is already uninstalled
+    FRAMEWORK_INSTALLED=$(kubectl get framework $2 -o jsonpath="{.metadata.name}")
+    if [ -z "$FRAMEWORK_INSTALLED" ]
+    then
+        echo -e "$2 is not an installed framework.\n"
+        echo ""
+        echo "Please choose from the list of available frameworks to uninstall:"
+        FRAMEWORKS_INSTALLED=$(kubectl get frameworks)
+        echo "$FRAMEWORKS_INSTALLED"
+        echo ""
+        echo "Syntax:"
+        echo -e "\tkubectl maestro uninstall <frameworkName>"
+        echo ""
+        echo "Example:"
+        echo -e "\tkubectl maestro uninstall kafka"
+        exit 1
+    else
+        echo "$2 framework is installed."
+    fi
+    framework=$2
+    while [ ! $# -eq 0 ]
+    do
+        case "$1" in
+            --all-dependencies | -a)
+                deleteDependencies $framework
+                exit 0
+                ;;
+        esac
+        shift
+    done
+    echo "Uninstalling $framework..."
+    frameworkLookup uninstall $framework
+    exit 0
+fi
+
+# shell argument handling
+if [[ "$1" == "shell" ]]
+then
+    if [[ "$2" == "flink" ]]
+    then
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        if [ -z "$JOBMANAGER_POD" ]
+        then
+            echo "No running jobmanager found."
+            exit 1
+        else
+            kubectl exec -i --tty $JOBMANAGER_POD -- /bin/bash
+            exit 0
+        fi
+    fi
+    echo "Please verify the framework to get a shell:"
+    kubectl get frameworks
+    echo ""
+    echo "Syntax: kubectl maestro shell <frameworkName>"
+    echo ""
+    echo "Example: kubectl maestro shell flink"
+    exit 1
+fi
+
+# exec argument handling
+if [[ "$1" == "exec" ]]
+then
+    if [[ "$2" == "flink" ]]
+    then
+        # Get current running jobmanager
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        if [ -z "$JOBMANAGER_POD" ]
+        then
+            echo "No running jobmanager found."
+            exit 1
+        else
+            kubectl exec -it $JOBMANAGER_POD -- ${@:3}
+            exit 0
+        fi
+    fi
+    echo "Please verify the framework to exec command:"
+    kubectl get frameworks
+    echo ""
+    echo "Syntax: kubectl maestro exec <frameworkName>"
+    echo ""
+    echo "Example: kubectl maestro exec flink"
+    exit 1
+fi
+
+# exec argument handling
+if [[ "$1" == "flink" ]]
+then
+    # Get current running jobmanager
+    JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+    if [ -z "$JOBMANAGER_POD" ]
+    then
+        echo "No running jobmanager found."
+        exit 1
+    else
+        kubectl exec -it $JOBMANAGER_POD -- bin/flink ${@:2}
+        exit 0
+    fi
+fi
+
+function createFunction {
+    framework=$2
+    shift 2
+    while getopts ":n:v:p:" opt ; do
+        case "$opt" in
+                p)   
+                c+=("$OPTARG")
+                ;;
+                n)
+                echo "name is: $OPTARG"
+                name=$OPTARG
+                ;;
+                v)
+                echo "version is: $OPTARG"
+                frameworkversion=$OPTARG
+                ;;                
+                \?)
+                echo "Invalid option: -$OPTARG" >&2
+                exit 1
+                ;;
+                :)
+                echo "Option -$OPTARG requires an argument." >&2
+                exit 1
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+    rm /tmp/maestro_instance_parameter
+    replace=": "
+    c+=("KUBECTL_PLUGIN:\"true\"")
+    for t in ${c[@]}; do
+        param_clean=${t/:/$replace}
+        cat <<EOF >> "/tmp/maestro_instance_parameter"
+        $param_clean
+EOF
+    done
+    cat <<EOF > "/tmp/maestro_instance"
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+    labels:
+        controller-tools.k8s.io: "1.0"
+        framework: $framework
+    name: $name
+spec:
+    frameworkVersion:
+        name: $framework-$frameworkversion
+        namespace: default
+        type: FrameworkVersion
+    parameters:
+EOF
+    cat /tmp/maestro_instance /tmp/maestro_instance_parameter > /tmp/maestro_instance_joined
+    kubectl apply -f /tmp/maestro_instance_joined
+}
+
+# create argument handling
+if [[ "$1" == "create" ]]
+then
+    createFunction "$@"
+    if [[ "$?" == "1" ]]
+    then
+        echo ""
+        echo "Failed to create instance for framework $2."
+        echo ""
+        echo "Invalid create command."
+        echo ""
+        echo "Syntax: kubectl maestro create -n <instanceName> -v <versionNumber> -p PARAM1=VALUE -p PARAM2=Value"
+        echo ""
+        echo "Example: kubectl maestro create kafka -n kafka -v 2.11-2.4.0 -p KAFKA_ZOOKEEPER_URI:zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 -p KAFKA_ZOOKEEPER_PATH:\"/small\" -p BROKERS_COUNT:\"3\""
+        exit 1
+    fi
+    exit 0
+fi
+
+# delete argument handling
+if [[ "$1" == "delete" ]]
+then
+    kubectl delete instance $2
+    if [[ "$?" == "1" ]]
+    then
+        echo ""
+        echo "Failed to delete instance $2."
+        echo ""
+        echo "Syntax: kubectl maestro delete <instanceName>"
+        echo ""
+        echo "Example: kubectl maestro delete kafka"
+        exit 1
+    fi
+    exit 0
+fi
+
+# scale argument handling
+if [[ "$1" == "scale" ]]
+then
+    kubectl scale deployment ${@:2}
+    if [[ "$?" == "1" ]]
+    then
+        kubectl scale statefulset ${@:2}
+        if [[ "$?" == "1" ]]
+        then
+        echo ""
+        echo "Failed to scale instance $2."
+        echo ""
+        echo "Syntax: kubectl maestro scale <instanceName> --replicas=<number>"
+        echo ""
+        echo "Example: kubectl maestro scale kafka --replicas=1"
+        exit 1
+        fi
+    fi
+    exit 0
+fi
+
+
+echo "Kubectl Maestro Plugin v0.0.1"
+echo ""
+echo "# Available commands"
+echo "kubectl maestro create -n <instanceName> -v <versionNumber> -p PARAM1=\"VALUE\" -p PARAM2=Value"
+echo "kubectl maestro delete <instanceName>"
+echo "kubectl maestro exec <Frameworkname>"
+echo "kubectl maestro flink <CLI Command>"
+echo "kubectl maestro scale <instanceName> --replicas=<number>"
+echo "kubectl maestro shell <Frameworkname>"

--- a/config/crds/maestro_v1alpha1_frameworkversion.yaml
+++ b/config/crds/maestro_v1alpha1_frameworkversion.yaml
@@ -38,6 +38,21 @@ spec:
               type: array
             framework:
               type: object
+            parameters:
+              items:
+                properties:
+                  default:
+                    type: string
+                  description:
+                    type: string
+                  displayName:
+                    type: string
+                  name:
+                    type: string
+                  required:
+                    type: boolean
+                type: object
+              type: array
             plans:
               type: object
             tasks:

--- a/config/crds/maestro_v1alpha1_instance.yaml
+++ b/config/crds/maestro_v1alpha1_instance.yaml
@@ -43,6 +43,8 @@ spec:
           properties:
             activePlan:
               type: object
+            status:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -93,6 +93,7 @@ rules:
   - maestro.k8s.io
   resources:
   - planexecutions
+  - instances
   verbs:
   - get
   - list

--- a/config/samples/canary.yaml
+++ b/config/samples/canary.yaml
@@ -1,0 +1,137 @@
+apiVersion: maestro.k8s.io/v1alpha1
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Framework
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: canary-app
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: canary-v1
+  namespace: default
+spec:
+  version: "1.0.0"
+  connectionString: ""
+  framework:
+    name: canary-app
+    kind: Framework
+  templates:
+      #change deployment name.
+      # change image tag to canary
+      # change
+    deployment.yaml: |
+      apiVersion: apps/v1beta2
+      kind: Deployment
+      metadata:
+        name: {{NAME}}
+        labels:
+          release: stable
+          app:  appinfo
+      spec:
+        replicas: {{REPLICAS}}
+        selector:
+          matchLabels:
+            app: appinfo
+        template:
+          metadata:
+            labels:
+              app: appinfo
+              release: stable
+            annotations:
+              prometheus.io/scrape: "true"
+          spec:
+            containers:
+            - name: appinfo-containers
+              image: runyonsolutions/appinfo:{{TAG}}
+              imagePullPolicy: Always
+              ports:
+              - containerPort: 8080
+              env:
+              - name: MY_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: MY_POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              volumeMounts:
+                - name: podinfo
+                  mountPath: /opt/
+            volumes:
+                - name: podinfo
+                  downwardAPI:
+                    items:
+                      - path: "labels"
+                        fieldRef:
+                          fieldPath: metadata.labels
+    service.yaml: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: appinfo
+        labels:
+          app: appinfo
+      spec:
+        ports:
+        - port: 8080
+          protocol: TCP
+        selector:
+          app: appinfo
+        type: LoadBalancer
+  tasks:
+    deployment:
+      resources:
+      - service.yaml
+      - deployment.yaml
+    deployment:
+      resources:
+      - deployment.yaml
+  parameters:
+  - name: TAG
+    description: "Docker image tag for runyonsolutions/appinfo"
+    default: "master"
+    required: false
+    displayName: "Image Tag"
+  - name: REPLICAS
+    description: "Replicas for application"
+    default: "3"
+    required: false
+    displayName: "Replicas"
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: all
+          strategy: parallel
+          steps:
+            - name: services
+              tasks:
+              - services
+            - name: deployment
+              tasks:
+              - deployment
+    canary:
+      strategy: serial
+      phases:
+        - name: deploy-canary
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    framework: canary
+  name: bird
+spec:
+  frameworkVersion:
+    name: canary-v1
+    namespace: default
+    type: FrameworkVersion
+  # Add fields here
+  parameters:
+    TAG: master

--- a/config/samples/flink-demo.yaml
+++ b/config/samples/flink-demo.yaml
@@ -1,0 +1,226 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Framework
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: flink-financial-demo
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: flink-financial-demo
+  namespace: default
+spec:
+  framework:
+    name: flink-financial-demo
+    kind: Framework
+  # Add fields here
+  parameters:
+  - name: DOWNLOAD_URL
+    description: URL To download the application from
+    default: "https://downloads.mesosphere.com/dcos-demo/flink/flink-job-1.0.jar"
+  templates:
+    zookeeper.yaml: |
+      apiVersion: maestro.k8s.io/v1alpha1
+      kind: Instance
+      metadata:
+        labels:
+          controller-tools.k8s.io: "1.0"
+          framework: zookeeper
+        name: zk
+      spec:
+        frameworkVersion:
+          name: zookeeper-1.0
+          namespace: default
+          type: FrameworkVersions
+        # Add fields here
+        name: "zk"
+        parameters:
+          ZOOKEEPER_CPUS: "0.3"
+    kafka.yaml: |
+      apiVersion: maestro.k8s.io/v1alpha1
+      kind: Instance
+      metadata:
+        labels:
+          controller-tools.k8s.io: "1.0"
+          framework: kafka 
+        name: kafka
+      spec:
+        frameworkVersion:
+          name: kafka-2.11-2.4.0
+          namespace: default
+          type: FrameworkVersion
+        parameters:
+          KAFKA_ZOOKEEPER_URI: "{{NAME}}-zk-{{NAME}}-zk-0.{{NAME}}-zk-hs:2181,{{NAME}}-zk-{{NAME}}-zk-1.{{NAME}}-zk-hs:2181,{{NAME}}-zk-{{NAME}}-zk-2.{{NAME}}-zk-hs:2181"
+          KAFKA_ZOOKEEPER_PATH: "/kafka"
+          BROKER_COUNT: "3"
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    flink.yaml: |
+      apiVersion: maestro.k8s.io/v1alpha1
+      kind: Instance
+      metadata:
+        labels:
+          controller-tools.k8s.io: "1.0"
+          framework: flink 
+        name: flink
+      spec:
+        frameworkVersion:
+          name: flink
+          namespace: default
+          type: FrameworkVersion
+    generator.yaml: |
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      metadata:
+        name: generator
+      spec:
+        replicas: 1
+        template:
+          metadata:
+            name: flink-demo-generator
+            labels:
+              app: flink-demo-generator
+          spec:
+            containers:
+            - name: flink-demo-generator
+              image: mesosphere/flink-generator:0.1
+              command: ["/generator-linux"]
+              imagePullPolicy: Always
+              args: ["--broker", "{{NAME}}-kafka-kafka-0.{{NAME}}-kafka-svc:9093"]
+    actor.yaml: |
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      metadata:
+        name: actor
+      spec:
+        replicas: 1
+        template:
+          metadata:
+            name: flink-demo-actor
+            labels:
+              app: flink-demo-actor
+          spec:
+            containers:
+            - name: actor
+              image: mesosphere/flink-demo-actor:0.2
+              command: ["/fraudDisplay-linux"]
+              imagePullPolicy: Always
+              args: ["--broker", "{{NAME}}-kafka-kafka-0.{{NAME}}-kafka-svc:9093"]
+    uploader.yaml: |
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: default
+        name: submit-flink-job
+      spec:
+        template:
+          metadata:
+            name: {{PLAN_NAME}}-job
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - env:
+              - name: DOWNLOAD_URL
+                value: {{DOWNLOAD_URL}}
+              - name: JOBMANAGER
+                value: {{NAME}}-flink-jobmanager
+              name: {{PLAN_NAME}}
+              image: bash
+              imagePullPolicy: Always
+              command:
+                - "/usr/local/bin/bash"
+              args: ['-c',
+              'export JOB_FILENAME=$(basename $DOWNLOAD_URL); echo "DOWNLOAD_URL: $DOWNLOAD_URL FILE: $JOB_FILENAME JOBMANAGER: $JOBMANAGER"; apk add --no-cache jq curl;
+              curl -s $DOWNLOAD_URL -o $JOB_FILENAME;
+              curl -s -X POST -H "Expect:" -F "jarfile=@$JOB_FILENAME" $JOBMANAGER:8081/jars/upload;
+              while true; do date; export JAR_ID=$(curl -s $JOBMANAGER:8081/jars | jq -r ".files[].id");
+              if [ -z $JAR_ID ];
+              then
+              echo "No uploaded jar detected";
+              else
+              echo "Found jar $JAR_ID";
+              export SUBMIT_MSG=$(curl -s -X POST -H "Expect:" $JOBMANAGER:8081/jars/$JAR_ID/run?program-args=--kafka_host%20{{NAME}}-kafka-kafka-1.{{NAME}}-kafka-svc.default.svc.cluster.local:9093 | jq -r ".errors");
+              echo "RESPONSE: $SUBMIT_MSG";
+              if [ $SUBMIT_MSG == "null" ];
+              then
+              echo "SUBMITTED JOB!";
+              exit 0;
+              else
+              echo "Failed to submit job: $SUBMIT_MSG";
+              fi;
+              fi;
+              echo "=====================";
+              sleep 5; done;']
+  tasks:
+    kafka:
+      resources:
+      - kafka.yaml
+    zookeeper:
+      resources:
+      - zookeeper.yaml
+    flink:
+      resources:
+      - flink.yaml
+    generator:
+      resources:
+      - generator.yaml
+    actor:
+      resources:
+      - actor.yaml
+    upload:
+      resources:
+      - uploader.yaml
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: dependencies
+          strategy: serial
+          steps:
+            - name: zookeeper
+              tasks:
+              - zookeeper
+            - name: kafka
+              tasks:
+              - kafka
+        - name: flink-cluster
+          strategy: serial
+          steps:
+            - name: flink
+              tasks:
+              - flink
+        - name: demo
+          strategy: serial
+          steps:
+            - name: gen
+              tasks:
+              - generator
+            - name: act
+              tasks:
+              - actor
+    upload:
+      strategy: serial
+      phases:
+        - name: dependencies
+          strategy: serial
+          steps:
+            - name: upload
+              tasks:
+              - upload
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    framework: flink-financial-demo
+  name: demo
+spec:
+  frameworkVersion:
+    name: flink-financial-demo
+    namespace: default
+    type: FrameworkVersion
+  parameters:
+    NONE: "true"

--- a/config/samples/flink-demo/Dockerfile
+++ b/config/samples/flink-demo/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+
+RUN apt-get update && apt-get install -y curl wget jq
+
+ADD upload.sh /
+
+
+
+CMD ["/upload.sh"]

--- a/config/samples/flink-demo/upload.sh
+++ b/config/samples/flink-demo/upload.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+wget -O job.jar ${DOWNLOAD_URL}
+curl -X POST -H "Expect:" -F "jarfile=@job.jar" http://${JOBMANAGER}:8081/jars/upload | jq .
+sleep 5
+jarid=`curl http://${JOBMANAGER}:8081/jars?name=job.jar | jq -r .files[0].id`
+sleep 5
+jobid=`curl -XPOST -d '{}' http://${JOBMANAGER}:8081/jars/$jarid/run | jq .`
+
+echo "Running job $jobid"

--- a/config/samples/flink.yaml
+++ b/config/samples/flink.yaml
@@ -1,0 +1,126 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Framework
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: flink
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: flink
+  namespace: default
+spec:
+  framework:
+    name: flink
+    kind: Framework
+  # Add fields here
+  version: "1.0"
+  parameters:
+  - name: FLINK_TASKMANAGER_REPLICAS
+    description: Number of task managers to run
+    default: "2"
+  - name: FLINK_JOBMANAGER_REPLICAS
+    description: Number of job managers to run
+    default: "2"
+  templates:
+    services.yaml: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: jobmanager
+      spec:
+        ports:
+        - name: rpc
+          port: 6123
+        - name: blob
+          port: 6124
+        - name: query
+          port: 6125
+        - name: ui
+          port: 8081
+        selector:
+          app: flink
+          component: jobmanager
+    taskmanager-deployment.yaml: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: taskmanager
+      spec:
+        replicas: {{FLINK_TASKMANAGER_REPLICAS}}
+        template:
+          metadata:
+            labels:
+              app: flink
+              component: taskmanager
+          spec:
+            containers:
+            - name: taskmanager
+              image: flink:latest
+              args:
+              - taskmanager
+              ports:
+              - containerPort: 6121
+                name: data
+              - containerPort: 6122
+                name: rpc
+              - containerPort: 6125
+                name: query
+              env:
+              - name: JOB_MANAGER_RPC_ADDRESS
+                value: {{NAME}}-jobmanager 
+    jobmanager-deployment.yaml: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: jobmanager
+      spec:
+        replicas: {{FLINK_JOBMANAGER_REPLICAS}}
+        template:
+          metadata:
+            labels:
+              app: flink
+              component: jobmanager
+          spec:
+            containers:
+            - name: jobmanager
+              image: flink:latest
+              args:
+              - jobmanager
+              ports:
+              - containerPort: 6123
+                name: rpc
+              - containerPort: 6124
+                name: blob
+              - containerPort: 6125
+                name: query
+              - containerPort: 8081
+                name: ui
+              env:
+              - name: JOB_MANAGER_RPC_ADDRESS
+                value: {{NAME}}-jobmanager
+  tasks:
+    jobmanager:
+      resources:
+      - jobmanager-deployment.yaml
+    jobmanager-service:
+      resources:
+      - services.yaml
+    taskmanager:
+      resources:
+      - taskmanager-deployment.yaml
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: flink
+          strategy: serial
+          steps:
+            - name: jobmanager
+              tasks:
+              - jobmanager
+              - jobmanager-service
+              - taskmanager

--- a/config/samples/kubectl-maestro
+++ b/config/samples/kubectl-maestro
@@ -1,0 +1,382 @@
+#!/bin/bash
+
+KAFKA_DEPENDENCY_LIST=("zookeeper")
+FLINK_DEPENDENCY_LIST=("kafka" "zookeeper")
+
+# optional argument handling
+if [[ "$1" == "version" ]]
+then
+    echo "0.0.1"
+    exit 0
+fi
+
+function frameworkInstall {
+    if [[ "$1" == "" ]]
+    then
+        echo "Cannot install empty framework."
+        exit 1
+    else
+        if [[ "$1" == "flink" ]]
+        then
+            echo "Installing $1 framework..."
+            kubectl apply -f https://raw.githubusercontent.com/maestrosdk/maestro/bf665a30809fa5c18ecee6396203472e252fa15d/config/samples/flink.yaml
+            if [[ "$?" == "1" ]]
+            then
+                echo "Failed to install framework flink."
+                exit 1
+            fi
+            echo "Flink framework successfully installed."
+            exit 0
+        fi
+        echo "Installing $1 framework..."
+        kubectl apply -f https://raw.githubusercontent.com/maestrosdk/maestro/master/config/samples/$1-framework.yaml
+        kubectl apply -f https://raw.githubusercontent.com/maestrosdk/maestro/master/config/samples/$1-frameworkversion.yaml
+        if [[ "$?" == "1" ]]
+        then
+            echo "Failed to install framework $1"
+            exit 1
+        fi
+    fi
+}
+
+function frameworkUninstall {
+    if [[ "$1" == "" ]]
+    then
+        echo "Cannot uninstall empty framework."
+        exit 1
+    else
+        if [[ "$1" == "flink" ]]
+        then
+            echo "Uninstalling $1 framework..."
+            kubectl delete -f https://raw.githubusercontent.com/maestrosdk/maestro/bf665a30809fa5c18ecee6396203472e252fa15d/config/samples/flink.yaml
+            if [[ "$?" == "1" ]]
+            then
+                echo "Failed to uninstall framework flink."
+                exit 1
+            fi
+            echo "Flink framework successfully uninstalled."
+            exit 0
+        fi
+        echo "Uninstalling $1 framework..."
+        kubectl delete -f https://raw.githubusercontent.com/maestrosdk/maestro/master/config/samples/$1-framework.yaml
+        kubectl delete -f https://raw.githubusercontent.com/maestrosdk/maestro/master/config/samples/$1-frameworkversion.yaml
+        if [[ "$?" == "1" ]]
+        then
+            echo "Failed to uninstall framework $1"
+            exit 1
+        fi
+    fi
+}
+
+function compareArray {
+  awk 'BEGIN{RS=ORS=" "}
+       {NR==FNR?a[$0]++:a[$0]--}
+       END{for(k in a)if(a[k])print k}' <(echo -n "${!1}") <(echo -n "${!2}")
+}
+
+# install argument handling
+if [[ "$1" == "install" ]]
+then
+    if ! [ -x "$(command -v jq)" ]; then
+        echo 'Error: jq is not installed.' >&2
+        exit 1
+    fi
+    if [[ "$2" == "flink" ]]
+    then
+        # checking to see if Flink framework is already installed
+        FLINK_INSTALLED=$(kubectl get framework flink -o jsonpath="{.metadata.name}")
+        if [ -z "$FLINK_INSTALLED" ]
+        then
+            echo "Flink framework has not been installed yet."
+        else
+            echo "Flink framework already installed."
+            exit 1
+            #todo: installFlinkInstance
+        fi
+
+        # checking dependencies
+        echo "Checking for Flink dependencies..."
+
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${FLINK_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
+        if [ -z "$FRAMEWORKS_INSTALLED" ]
+        then
+            echo "No dependency frameworks are installed."
+            ## now loop through the dependencies to install
+            for d in "${FLINK_DEPENDENCY_LIST[@]}"
+            do
+            frameworkInstall $d
+            done
+            frameworkInstall flink
+            exit 0
+        else
+            #TO_INSTALL_FRAMEWORKS=$(${FRAMEWORKS_INSTALLED[@]} ${FLINK_DEPENDENCY_LIST[@]} | tr ' ' '\n' | sort | uniq -u)7
+            #TO_INSTALL_FRAMEWORKS=${FLINK_DEPENDENCY_LIST[@]} ${FRAMEWORKS_INSTALLED[@]} ${FRAMEWORKS_INSTALLED[@]} | tr ' ' '\n' | sort | uniq -u
+            #echo $TO_INSTALL_FRAMEWORKS
+            TO_INSTALL_FRAMEWORKS=($(compareArray FLINK_DEPENDENCY_LIST[@] FRAMEWORKS_INSTALLED[@]))
+            if [ -z "$TO_INSTALL_FRAMEWORKS" ]
+            then
+                echo "All dependency frameworks are installed."
+                frameworkInstall flink
+            else
+                echo -e "Found missing framework(s):\n\t${TO_INSTALL_FRAMEWORKS[@]}"
+                for d in "${TO_INSTALL_FRAMEWORKS[@]}"
+                do
+                frameworkInstall $d
+                done
+                echo "All dependency frameworks are installed now."
+                frameworkInstall flink
+            fi
+        fi
+    elif [[ "$2" == "kafka" ]]
+    then
+        # checking to see if Kafka framework is already installed
+        KAFKA_INSTALLED=$(kubectl get framework kafka -o jsonpath="{.metadata.name}")
+        if [ -z "$KAFKA_INSTALLED" ]
+        then
+            echo "KAFKA framework has not been installed yet."
+        else
+            echo "KAFKA framework already installed."
+            exit 1
+        fi
+
+        # checking dependencies
+        echo "Checking for Kafka dependencies..."
+
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${KAFKA_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
+        if [ -z "$FRAMEWORKS_INSTALLED" ]
+        then
+            echo "No dependency frameworks are installed."
+            ## now loop through the dependencies to install
+            for d in "${KAFKA_DEPENDENCY_LIST[@]}"
+            do
+            frameworkInstall $d
+            done
+            frameworkInstall kafka
+            exit 0
+        else
+            TO_INSTALL_FRAMEWORKS=($(compareArray KAFKA_DEPENDENCY_LIST[@] FRAMEWORKS_INSTALLED[@]))
+            if [ -z "$TO_INSTALL_FRAMEWORKS" ]
+            then
+                echo "All dependency frameworks are installed."
+                frameworkInstall kafka
+            else
+                echo -e "Found missing framework(s):\n\t${TO_INSTALL_FRAMEWORKS[@]}"
+                for d in "${TO_INSTALL_FRAMEWORKS[@]}"
+                do
+                frameworkInstall $d
+                done
+                echo "All dependency frameworks are installed now."
+                frameworkInstall kafka
+            fi
+        fi
+    elif [[ "$2" == "zookeeper" ]]
+    then
+        # checking to see if Zookeeper framework is already installed
+        ZOOKEEPER_INSTALLED=$(kubectl get framework zookeeper -o jsonpath="{.metadata.name}")
+        if [ -z "$ZOOKEEPER_INSTALLED" ]
+        then
+            echo "Zookeeper framework has not been installed yet."
+            frameworkInstall zookeeper
+            exit 0
+        else
+            echo "Zookeeper framework already installed."
+            exit 1
+        fi
+    else
+        echo -e "$2 is not a known framework.\n"
+        echo "Please select the framework to install:"
+        sampleRegistry=$(curl -s https://api.github.com/repos/maestrosdk/maestro/contents/config/samples | jq -r ".[] | .name ")
+        echo ""
+        for t in ${sampleRegistry[@]}; do
+            if [[ $t == *"framework.yaml" ]]; then
+                #echo -e "\t$t"
+                echo -e "\t${t%-framework.yaml*}"
+            fi
+        done
+
+        # hack to always show flink until we refactored config/samples
+        echo -e "\tflink"
+        echo ""
+        echo "Syntax:"
+        echo -e "\tkubectl maestro install <frameworkName>"
+        echo ""
+        echo "Example:"
+        echo -e "\tkubectl maestro install flink"
+        exit 1
+    fi
+fi
+
+# uninstall argument handling
+if [[ "$1" == "uninstall" ]]
+then
+    if ! [ -x "$(command -v jq)" ]; then
+        echo 'Error: jq is not installed.' >&2
+        exit 1
+    fi
+    if [[ "$2" == "flink" ]]
+    then
+        # checking to see if Flink framework is already uninstalled
+        FLINK_INSTALLED=$(kubectl get framework flink -o jsonpath="{.metadata.name}")
+        if [ -z "$FLINK_INSTALLED" ]
+        then
+            echo "Flink framework is already uninstalled."
+            exit 1
+
+        else
+            echo "Flink framework is installed."
+        fi
+
+        # checking dependencies
+        echo "Checking for Flink dependencies..."
+
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${FLINK_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
+        if [ -z "$FRAMEWORKS_INSTALLED" ]
+        then
+            echo "Dependency frameworks are uninstalled."
+            frameworkUninstall flink
+        else
+            echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
+            for i in "${FLINK_DEPENDENCY_LIST[@]}"
+            do
+            frameworkUninstall $i
+            done
+            echo "All dependency frameworks are uninstalled now."
+            frameworkUninstall flink
+        fi
+    elif [[ "$2" == "kafka" ]]
+    then
+        # checking to see if Kafka framework is already uninstalled
+        KAFKA_INSTALLED=$(kubectl get framework kafka -o jsonpath="{.metadata.name}")
+        if [ -z "$KAFKA_INSTALLED" ]
+        then
+            echo "Kafka framework is already uninstalled."
+            exit 1
+
+        else
+            echo "Kafka framework is installed."
+        fi
+
+        # checking dependencies
+        echo "Checking for Kafka dependencies..."
+
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${KAFKA_DEPENDENCY_LIST[@]} -o jsonpath="{.metadata.name}")
+        if [ -z "$FRAMEWORKS_INSTALLED" ]
+        then
+            echo "No dependency frameworks are uninstalled."
+            frameworkUninstall kafka
+        else
+            echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
+            for d in "${FRAMEWORKS_INSTALLED[@]}"
+            do
+            frameworkUninstall $d
+            done
+            echo "All dependency frameworks are uninstalled now."
+            frameworkUninstall kafka
+            exit 0
+        fi
+    elif [[ "$2" == "zookeeper" ]]
+    then
+        # checking to see if Kafka framework is already uninstalled
+        ZOOKEEPER_INSTALLED=$(kubectl get framework zookeeper -o jsonpath="{.metadata.name}")
+        if [ -z "$ZOOKEEPER_INSTALLED" ]
+        then
+            echo "Zookeeper framework is already uninstalled."
+            exit 1
+
+        else
+            echo "Zookeeper framework is installed."
+            frameworkUninstall zookeeper
+            exit 0
+        fi
+    else
+        echo -e "$2 is not a known framework.\n"
+        echo "Please choose from the list of frameworks to uninstall:"
+        FRAMEWORKS_INSTALLED=$(kubectl get frameworks -o jsonpath="{.items[*].metadata.name}")
+        echo ""
+        for t in ${FRAMEWORKS_INSTALLED[@]}; do
+            echo -e "\t$t"
+        done
+        echo ""
+        echo "Syntax:"
+        echo -e "\tkubectl maestro uninstall <frameworkName>"
+        echo ""
+        echo "Example:"
+        echo -e "\tkubectl maestro uninstall kafka"
+        exit 1
+    fi
+fi
+
+# shell argument handling
+if [[ "$1" == "shell" ]]
+then
+    if [[ "$2" == "flink" ]]
+    then
+        # --generator=run-pod/v1 -it --rm --image=superorbital/bash --restart=Never -- curl http://demo-flink-jobmanager:8081/jars
+        # kubectl run -i --tty --rm bash --image=bash --restart=Never -- bash -c "curl http://demo-flink-jobmanager:8081/jars"
+        #kubectl run shell ${@:2}
+        # Get current running jobmanager
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        if [ -z "$JOBMANAGER_POD" ]
+        then
+            echo "No running jobmanager found."
+            exit 1
+        else
+            kubectl exec -i --tty $JOBMANAGER_POD -- /bin/bash
+            exit 0
+        fi
+    fi
+    echo "Please verify the framework to get a shell:"
+    kubectl get frameworks
+    echo ""
+    echo "Syntax: kubectl maestro shell <frameworkName>"
+    echo ""
+    echo "Example: kubectl maestro shell flink"
+    exit 1
+fi
+
+# exec argument handling
+if [[ "$1" == "exec" ]]
+then
+    if [[ "$2" == "flink" ]]
+    then
+        # Get current running jobmanager
+        JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+        if [ -z "$JOBMANAGER_POD" ]
+        then
+            echo "No running jobmanager found."
+            exit 1
+        else
+            kubectl exec -it $JOBMANAGER_POD -- ${@:3}
+            exit 0
+        fi
+    fi
+    echo "Please verify the framework to exec command:"
+    kubectl get frameworks
+    echo ""
+    echo "Syntax: kubectl maestro exec <frameworkName>"
+    echo ""
+    echo "Example: kubectl maestro exec flink"
+    exit 1
+fi
+
+# exec argument handling
+if [[ "$1" == "flink" ]]
+then
+    # Get current running jobmanager
+    JOBMANAGER_POD=$(kubectl get pods -l heritage=maestro,component=jobmanager --field-selector=status.phase==Running -o jsonpath="{.items[0].metadata.name}")
+    if [ -z "$JOBMANAGER_POD" ]
+    then
+        echo "No running jobmanager found."
+        exit 1
+    else
+        kubectl exec -it $JOBMANAGER_POD -- bin/flink ${@:2}
+        exit 0
+    fi
+fi
+
+echo "Kubectl Maestro Plugin v0.0.1"
+echo ""
+echo "# Available commands"
+echo "kubectl maestro shell <Frameworkname>"
+echo "kubectl maestro exec <Frameworkname>"
+echo "kubectl maestro flink <CLI Command>"

--- a/config/samples/kubectl-maestro
+++ b/config/samples/kubectl-maestro
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-KAFKA_DEPENDENCY_LIST=("zookeeper")
-FLINK_DEPENDENCY_LIST=("kafka" "zookeeper")
+kafka_dependency_list=("zookeeper")
+flink_dependency_list=("kafka" "zookeeper")
 
 # optional argument handling
 if [[ "$1" == "version" ]]
@@ -68,6 +68,34 @@ function frameworkUninstall {
     fi
 }
 
+function deleteDependencies {
+    # checking dependencies
+    echo "Checking for $1 dependencies..."
+    # copying from the right array
+    eval dependency_list=('$'{$1_dependency_list[@]})
+    # adjusting the kubectl command for the case of a single dependency
+    if [[ ${#dependency_list[@]} -lt "2" ]]
+    then
+        jsonpath=".metadata.name"
+    else
+        jsonpath=".items[*].metadata.name"
+    fi
+    FRAMEWORKS_INSTALLED=$(kubectl get framework ${dependency_list[@]} -o jsonpath="{$jsonpath}")
+    if [ -z "$FRAMEWORKS_INSTALLED" ]
+    then
+        echo "Dependency frameworks are uninstalled."
+        frameworkUninstall $1
+    else
+        echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
+        for i in "${dependency_list[@]}"
+        do
+        frameworkUninstall $i
+        done
+        echo "All dependency frameworks are uninstalled now."
+        frameworkUninstall $1
+    fi
+}
+
 function compareArray {
   awk 'BEGIN{RS=ORS=" "}
        {NR==FNR?a[$0]++:a[$0]--}
@@ -97,22 +125,22 @@ then
         # checking dependencies
         echo "Checking for Flink dependencies..."
 
-        FRAMEWORKS_INSTALLED=$(kubectl get framework ${FLINK_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${flink_dependency_list[@]} -o jsonpath="{.items[*].metadata.name}")
         if [ -z "$FRAMEWORKS_INSTALLED" ]
         then
             echo "No dependency frameworks are installed."
             ## now loop through the dependencies to install
-            for d in "${FLINK_DEPENDENCY_LIST[@]}"
+            for d in "${flink_dependency_list[@]}"
             do
             frameworkInstall $d
             done
             frameworkInstall flink
             exit 0
         else
-            #TO_INSTALL_FRAMEWORKS=$(${FRAMEWORKS_INSTALLED[@]} ${FLINK_DEPENDENCY_LIST[@]} | tr ' ' '\n' | sort | uniq -u)7
-            #TO_INSTALL_FRAMEWORKS=${FLINK_DEPENDENCY_LIST[@]} ${FRAMEWORKS_INSTALLED[@]} ${FRAMEWORKS_INSTALLED[@]} | tr ' ' '\n' | sort | uniq -u
+            #TO_INSTALL_FRAMEWORKS=$(${FRAMEWORKS_INSTALLED[@]} ${flink_dependency_list[@]} | tr ' ' '\n' | sort | uniq -u)7
+            #TO_INSTALL_FRAMEWORKS=${flink_dependency_list[@]} ${FRAMEWORKS_INSTALLED[@]} ${FRAMEWORKS_INSTALLED[@]} | tr ' ' '\n' | sort | uniq -u
             #echo $TO_INSTALL_FRAMEWORKS
-            TO_INSTALL_FRAMEWORKS=($(compareArray FLINK_DEPENDENCY_LIST[@] FRAMEWORKS_INSTALLED[@]))
+            TO_INSTALL_FRAMEWORKS=($(compareArray flink_dependency_list[@] FRAMEWORKS_INSTALLED[@]))
             if [ -z "$TO_INSTALL_FRAMEWORKS" ]
             then
                 echo "All dependency frameworks are installed."
@@ -133,28 +161,28 @@ then
         KAFKA_INSTALLED=$(kubectl get framework kafka -o jsonpath="{.metadata.name}")
         if [ -z "$KAFKA_INSTALLED" ]
         then
-            echo "KAFKA framework has not been installed yet."
+            echo "Kafka framework has not been installed yet."
         else
-            echo "KAFKA framework already installed."
+            echo "Kafka framework already installed."
             exit 1
         fi
 
         # checking dependencies
         echo "Checking for Kafka dependencies..."
 
-        FRAMEWORKS_INSTALLED=$(kubectl get framework ${KAFKA_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
+        FRAMEWORKS_INSTALLED=$(kubectl get framework ${kafka_dependency_list[@]} -o jsonpath="{.items[*].metadata.name}")
         if [ -z "$FRAMEWORKS_INSTALLED" ]
         then
             echo "No dependency frameworks are installed."
             ## now loop through the dependencies to install
-            for d in "${KAFKA_DEPENDENCY_LIST[@]}"
+            for d in "${kafka_dependency_list[@]}"
             do
             frameworkInstall $d
             done
             frameworkInstall kafka
             exit 0
         else
-            TO_INSTALL_FRAMEWORKS=($(compareArray KAFKA_DEPENDENCY_LIST[@] FRAMEWORKS_INSTALLED[@]))
+            TO_INSTALL_FRAMEWORKS=($(compareArray kafka_dependency_list[@] FRAMEWORKS_INSTALLED[@]))
             if [ -z "$TO_INSTALL_FRAMEWORKS" ]
             then
                 echo "All dependency frameworks are installed."
@@ -226,23 +254,19 @@ then
             echo "Flink framework is installed."
         fi
 
-        # checking dependencies
-        echo "Checking for Flink dependencies..."
-
-        FRAMEWORKS_INSTALLED=$(kubectl get framework ${FLINK_DEPENDENCY_LIST[@]} -o jsonpath="{.items[*].metadata.name}")
-        if [ -z "$FRAMEWORKS_INSTALLED" ]
-        then
-            echo "Dependency frameworks are uninstalled."
-            frameworkUninstall flink
-        else
-            echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
-            for i in "${FLINK_DEPENDENCY_LIST[@]}"
-            do
-            frameworkUninstall $i
-            done
-            echo "All dependency frameworks are uninstalled now."
-            frameworkUninstall flink
-        fi
+        while [ ! $# -eq 0 ]
+        do
+            case "$1" in
+                --all-dependencies | -a)
+                    deleteDependencies flink
+                    exit 0
+                    ;;
+            esac
+            shift
+        done
+        echo "Uninstalling Flink..."
+        frameworkUninstall flink
+        exit 0
     elif [[ "$2" == "kafka" ]]
     then
         # checking to see if Kafka framework is already uninstalled
@@ -256,24 +280,19 @@ then
             echo "Kafka framework is installed."
         fi
 
-        # checking dependencies
-        echo "Checking for Kafka dependencies..."
-
-        FRAMEWORKS_INSTALLED=$(kubectl get framework ${KAFKA_DEPENDENCY_LIST[@]} -o jsonpath="{.metadata.name}")
-        if [ -z "$FRAMEWORKS_INSTALLED" ]
-        then
-            echo "No dependency frameworks are uninstalled."
-            frameworkUninstall kafka
-        else
-            echo -e "Found installed dependency framework(s):\n\t${FRAMEWORKS_INSTALLED[@]}"
-            for d in "${FRAMEWORKS_INSTALLED[@]}"
-            do
-            frameworkUninstall $d
-            done
-            echo "All dependency frameworks are uninstalled now."
-            frameworkUninstall kafka
-            exit 0
-        fi
+        while [ ! $# -eq 0 ]
+        do
+            case "$1" in
+                --all-dependencies | -a)
+                    deleteDependencies kafka
+                    exit 0
+                    ;;
+            esac
+            shift
+        done
+        echo "Uninstalling Kafka..."
+        frameworkUninstall kafka
+        exit 0
     elif [[ "$2" == "zookeeper" ]]
     then
         # checking to see if Kafka framework is already uninstalled
@@ -372,6 +391,96 @@ then
         kubectl exec -it $JOBMANAGER_POD -- bin/flink ${@:2}
         exit 0
     fi
+fi
+
+function createFunction {
+    framework=$2
+    shift 2
+    while getopts ":n:v:p:" opt ; do
+        case "$opt" in
+                p)   
+                c+=("$OPTARG")
+                ;;
+                n)
+                echo "name is: $OPTARG"
+                name=$OPTARG
+                ;;
+                v)
+                echo "version is: $OPTARG"
+                frameworkversion=$OPTARG
+                ;;                
+                \?)
+                echo "Invalid option: -$OPTARG" >&2
+                exit 1
+                ;;
+                :)
+                echo "Option -$OPTARG requires an argument." >&2
+                exit 1
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+    rm /tmp/maestro_instance_parameter
+    replace=": "
+    for t in ${c[@]}; do
+        param_clean=${t/:/$replace}
+        cat <<EOF >> "/tmp/maestro_instance_parameter"
+        $param_clean
+EOF
+    done
+    cat <<EOF > "/tmp/maestro_instance"
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+    labels:
+        controller-tools.k8s.io: "1.0"
+        framework: $framework
+    name: $name
+spec:
+    frameworkVersion:
+        name: $framework-$frameworkversion
+        namespace: default
+        type: FrameworkVersion
+    parameters:
+EOF
+    cat /tmp/maestro_instance /tmp/maestro_instance_parameter > /tmp/maestro_instance_joined
+    kubectl apply -f /tmp/maestro_instance_joined
+}
+
+# create argument handling
+if [[ "$1" == "create" ]]
+then
+    createFunction "$@"
+    if [[ "$?" == "1" ]]
+    then
+        echo ""
+        echo "Failed to create instance for framework $2."
+        echo ""
+        echo "Invalid create command."
+        echo ""
+        echo "Syntax: kubectl maestro create -n <instanceName> -v <versionNumber> -p PARAM1=VALUE -p PARAM2=Value"
+        echo ""
+        echo "Example: kubectl maestro create kafka -n kafka -v 2.11-2.4.0 -p KAFKA_ZOOKEEPER_URI:zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 -p KAFKA_ZOOKEEPER_PATH:/small -p BROKERS_COUNT:3"
+        exit 1
+    fi
+    exit 0
+fi
+
+# delete argument handling
+if [[ "$1" == "delete" ]]
+then
+    kubectl delete instance $2
+    if [[ "$?" == "1" ]]
+    then
+        echo ""
+        echo "Failed to delete instance $2."
+        echo ""
+        echo "Syntax: kubectl maestro delete <instanceName> -v <versionNumber> -p PARAM1=VALUE -p PARAM2=Value"
+        echo ""
+        echo "Example: kubectl maestro delete kafka"
+        exit 1
+    fi
+    exit 0
 fi
 
 echo "Kubectl Maestro Plugin v0.0.1"

--- a/config/samples/zookeeper-frameworkversion.yaml
+++ b/config/samples/zookeeper-frameworkversion.yaml
@@ -128,22 +128,6 @@ spec:
                     --max_session_timeout=40000 \
                     --min_session_timeout=4000 \
                     --log_level=INFO"
-                readinessProbe:
-                  exec:
-                    command:
-                      - sh
-                      - -c
-                      - "zookeeper-ready 2181"
-                  initialDelaySeconds: 10
-                  timeoutSeconds: 5
-                livenessProbe:
-                  exec:
-                    command:
-                      - sh
-                      - -c
-                      - "zookeeper-ready 2181"
-                  initialDelaySeconds: 10
-                  timeoutSeconds: 5
                 volumeMounts:
                   - name: datadir
                     mountPath: /var/lib/zookeeper

--- a/config/scratch/mysql-backup.yaml
+++ b/config/scratch/mysql-backup.yaml
@@ -1,0 +1,14 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  labels:
+    framework-version: mysql-57
+    instance: mysql
+  name: mysql-backup
+  namespace: default
+spec:
+  instance:
+    kind: Instance
+    name: mysql
+    namespace: default
+  planName: backup

--- a/config/scratch/mysql-restore.yaml
+++ b/config/scratch/mysql-restore.yaml
@@ -1,0 +1,14 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  labels:
+    framework-version: mysql-57
+    instance: mysql
+  name: mysql-restore
+  namespace: default
+spec:
+  instance:
+    kind: Instance
+    name: mysql
+    namespace: default
+  planName: restore

--- a/config/scratch/validation.yaml
+++ b/config/scratch/validation.yaml
@@ -1,0 +1,19 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  labels:
+    instance: up
+  name: validation
+  namespace: default
+  ownerReferences:
+  - apiVersion: maestro.k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Instance
+    name: small
+spec:
+  instance:
+    kind: Instance
+    name: small
+    namespace: default
+  planName: validation

--- a/docs/ApplicationUpgrades.md
+++ b/docs/ApplicationUpgrades.md
@@ -1,0 +1,27 @@
+# Maestro Managing Deployment Upgrades
+
+
+
+## Register Rollout plan for Parameter
+
+The operations required to safely update a running application can vary depending on which parameter is
+being updated.  For instance updating the `BROKER_COUNT`, may require a simple update of the deployment, whereas
+updating the `APPLICATION_MEMORY` may require rolling out a new version via a canary or blue/green deployment.
+
+Each parameter can be configured with a default update plan via the `deploy` plan that is required by all `FrameworkVersions`.
+
+```yaml
+...
+spec:
+  parameters:
+  - name: REPLICAS
+    update: deploy
+  - name: APPLICATION_MEMORY
+    update: canary
+  plans:
+    canary:
+    ...
+    deploy:
+    ...
+```
+

--- a/docs/CLIUsage.md
+++ b/docs/CLIUsage.md
@@ -283,7 +283,7 @@ Install the plugin to your `PATH` e.g. in the maestro repo root via:
 
 |  Syntax | Description  | 
 |---|---|
-| `kubectl maestro create -n <instanceName> -v <versionNumber> -p PARAM1=\"VALUE\" -p PARAM2=Value`|  Creates an instance of an installed framework| 
+| `kubectl maestro create <framework> -n <instanceName> -v <versionNumber> -p PARAM1="\VALUE\" -p PARAM2=Value`|  Creates an instance of an installed framework| 
 | `kubectl maestro delete <instanceName>`|  Deletes a specified instance| 
 | `kubectl maestro exec <frameworkName>  <cmd>`|  Executes a command for a particular framework - right now just Flink supported | 
 | `kubectl maestro flink  <cmd>`|  Wrapper arround `Flink CLI` that supports all https://ci.apache.org/projects/flink/flink-docs-release-1.7/ops/cli.html commands | 
@@ -293,7 +293,8 @@ Install the plugin to your `PATH` e.g. in the maestro repo root via:
 | `kubectl maestro uninstall <frameworkName>` | Uninstalls just the specified framework/frameworkversion| 
 | `kubectl maestro scale <instanceName> --replicas=<number>` |  Scales an instance deployment/statefulset | 
 | `kubectl maestro shell` |  Lists all available frameworks of which you could get a shell  | 
-| `kubectl maestro shell <frameworkName>` |  gives you a shell - right now just Flink supported | 
+| `kubectl maestro shell <frameworkName>` | Gives you a shell - right now just Flink supported |
+| `kubectl maestro start -n <instanceName> -v <version> -p <planName>` | Starts a specified plan of your instance |
 
 Run `kubectl maestro install something` and you see a list of available frameworks:
 
@@ -314,8 +315,6 @@ Available incubating frameworks to install:
 
 ```bash
 maestro-demo $ kubectl maestro create kafka -n kafka -v 2.11-2.4.0 -p KAFKA_ZOOKEEPER_URI:zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 -p KAFKA_ZOOKEEPER_PATH:\"/small\" -p BROKERS_COUNT:\"3\"
-name is: kafka
-version is: 2.11-2.4.0
 instance.maestro.k8s.io/kafka created
 ```
 
@@ -395,4 +394,11 @@ stable framework kafka successfully uninstalled.
 maestro-demo $ kubectl maestro scale kafka-kafka --replicas=4
 Error from server (NotFound): deployments.extensions "kafka-kafka" not found
 statefulset.apps/kafka-kafka scaled
+```
+
+### Start Plan Example
+
+```bash
+maestro-demo $ kubectl maestro start -n demo -v flink-financial-demo -p upload
+planexecution.maestro.k8s.io/demo unchanged
 ```

--- a/docs/CLIUsage.md
+++ b/docs/CLIUsage.md
@@ -272,12 +272,15 @@ This includes the previous history but also all FrameworkVersions that have been
 
 ## Kubectl Maestro Plugin
 
+### Dependencies
+
+The Kubectl Plugin currently expects `jq` to be installed on the system.
+
 ### Install
 
 Install the plugin to your `PATH` e.g. in the maestro repo root via:
 
 - `ln -s $GOPATH/src/github.com/maestrosdk/maestro/cmd/kubectl-plugin/kubectl-maestro /usr/local/bin/kubectl-maestro`
-- Make it executable `chmod 755 $(GOPATH)/src/github.com/maestrosdk/maestro/cmd/kubectl-plugin/kubectl-maestro`
 
 ### Commands
 

--- a/docs/CLIUsage.md
+++ b/docs/CLIUsage.md
@@ -4,7 +4,7 @@ This document demonstrates how to use the CLI but also shows what happens in `Ma
 
 There are two CLIs you can use at the moment:
 
-- Maestrctl
+- Maestroctl
 - Kubectl Maestro Plugin
 
 ## Maestroctl

--- a/docs/DeleteObjectTasks.md
+++ b/docs/DeleteObjectTasks.md
@@ -1,0 +1,3 @@
+# Deleting Objects in Tasks
+
+Some specialized tasks require the deletion of objects defined in previous tasks. 

--- a/docs/Flink.md
+++ b/docs/Flink.md
@@ -1,0 +1,97 @@
+# Flink
+
+https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/kubernetes.html
+
+There's a note about running `minikube ssh 'sudo ip link set docker0 promisc on'`, need to dive into this and see if we understand the requirement.
+
+
+
+
+
+
+
+
+
+
+
+## Flink Demo
+
+
+
+
+This demo follows the outline provided by [DCOS's](https://github.com/dcos/demos/tree/master/flink-k8s/1.11) demo
+
+
+
+### Architecture
+
+We should modify the demo image to have everything run on K8s
+
+
+
+## Prerequisites
+
+Install the Kafka Framework and FrameworkVersion
+
+```bash
+kubectl apply -f config/samples/kafka-framework.yaml
+kubectl apply -f config/samples/kafka-frameworkversion.yaml
+```
+
+Install the Flink Framework and FrameworkVersion
+```bash
+kubectl apply -f config/samples/flink.yaml
+```
+
+
+## Deploy Plan
+The deployplan has several stages that can be read from the Flink file, but we ouline the Phases and steps here:
+
+### Kafka Phase
+
+#### Kafka Step
+The first phase is to create and deploy a Kafka instance:
+
+#### Create Topic Step
+
+The second Step in the phase runs a `Job` that creates a topic 
+
+### Flink Phase
+
+Now we need to install Flink on Kubernetes
+
+
+### Flink Generator Phase
+
+This phase deplos a `Flink` Genenerator that mirrors the deployment [here](https://github.com/dcos/demos/blob/master/flink-k8s/1.11/generator/flink-demo-generator.yaml)
+
+
+### Upload Flink Job to Flink
+
+We need to figure this out, but it could be a simple image that
+
+* downloads file from a URL that's an environment variable
+* uses CURL to upload the file into Flink
+
+### Flink Actor Phase
+
+This phase deploys a `Flink` actor that mirrors the deployment [here](kubectl apply -f https://raw.githubusercontent.com/dcos/demos/master/flink-k8s/1.11/actor/flink-demo-actor.yaml)
+
+
+
+# Scratch
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: maestro.k8s.io/v1alpha1
+kind: PlanExecution
+metadata:
+  name: upload
+  namespace: default
+spec:
+  instance:
+    kind: Instance
+    name: demo
+    namespace: default
+  planName: upload
+EOF
+```

--- a/pkg/apis/maestro/v1alpha1/instance_types.go
+++ b/pkg/apis/maestro/v1alpha1/instance_types.go
@@ -36,7 +36,7 @@ type InstanceStatus struct {
 
 	//TODO turn into struct
 	ActivePlan corev1.ObjectReference `json:"activePlan,omitempty"`
-
+	Status     PhaseState             `json:"status,omitempty"`
 	// PlanExecutionStatus PlanExecutionStatus `json:"status,omitempty"`
 }
 

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -131,7 +131,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 	}
 
-	// Watch for changes to PlanExecution
+	// Watch for changes to PlanExecution,
 	err = c.Watch(&source.Kind{Type: &maestrov1alpha1.PlanExecution{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
@@ -170,6 +170,17 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	err = c.Watch(
+		&source.Kind{Type: &maestrov1alpha1.Instance{}},
+		&handler.EnqueueRequestsFromMapFunc{
+			ToRequests: mapFn,
+		},
+		// Comment it if default predicate fun is used.
+		p)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -188,11 +199,10 @@ type ReconcilePlanExecution struct {
 // a Deployment as an example
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=maestro.k8s.io,resources=planexecutions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=maestro.k8s.io,resources=planexecutions;instances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets;poddisruptionbudgets.policy,verbs=get;list;watch;create;update;patch;delete
-
 func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the PlanExecution instance
 	planExecution := &maestrov1alpha1.PlanExecution{}
@@ -522,6 +532,12 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 		planExecution.Status.State = maestrov1alpha1.PhaseStateComplete
 	} else {
 		planExecution.Status.State = maestrov1alpha1.PhaseStateInProgress
+	}
+
+	instance.Status.Status = planExecution.Status.State
+	err = r.Client.Update(context.TODO(), instance)
+	if err != nil {
+		log.Printf("Error updating instance status to %v: %v\n", instance.Status.Status, err)
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/util/health/ready.go
+++ b/pkg/util/health/ready.go
@@ -2,7 +2,9 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
 	maestrov1alpha1 "github.com/maestrosdk/maestro/pkg/apis/maestro/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -17,7 +19,15 @@ func IsHealthy(c client.Client, obj runtime.Object) error {
 	switch obj.(type) {
 	case *appsv1.StatefulSet:
 		ss := obj.(*appsv1.StatefulSet)
-		if ss.Status.ReadyReplicas == ss.Status.Replicas {
+		log.Println("------HEALTH---------")
+		log.Printf("Looking at Statefulset: %v\n", ss.Name)
+		b, _ := json.MarshalIndent(ss, "", "\t")
+		log.Printf("\n%v\n", string(b))
+		log.Println("---------------------")
+		if ss.Spec.Replicas == nil {
+			return fmt.Errorf("replicas not set, so can't be healthy")
+		}
+		if ss.Status.ReadyReplicas == *ss.Spec.Replicas {
 			log.Printf("Statefulset %v is marked healthy\n", ss.Name)
 			return nil
 		}
@@ -46,10 +56,14 @@ func IsHealthy(c client.Client, obj runtime.Object) error {
 		i := obj.(*maestrov1alpha1.Instance)
 		//Instances are healthy when their Active Plan has succeeded
 		plan := &maestrov1alpha1.PlanExecution{}
-		c.Get(context.TODO(), client.ObjectKey{
+		err := c.Get(context.TODO(), client.ObjectKey{
 			Name:      i.Status.ActivePlan.Name,
 			Namespace: i.Status.ActivePlan.Namespace,
 		}, plan)
+		if err != nil {
+			log.Printf("Error getting PlaneExecution %v/%v: %v\n", i.Status.ActivePlan.Name, i.Status.ActivePlan.Namespace, err)
+			return fmt.Errorf("instance active plan not found: %v", err)
+		}
 		log.Printf("Instance %v is in state %v\n", i.Name, plan.Status.State)
 		if plan.Status.State == maestrov1alpha1.PhaseStateComplete {
 			return nil


### PR DESCRIPTION
This is a WIP.

Usage in combination with Flink, see this video https://cl.ly/2988619f8474

# Installation

Add `kubectl-maestro` to your `$PATH`.

# Commands

|  Syntax | Description  | 
|---|---|
| kubectl maestro install something  |  Lists all available frameworks from the `Maestro App Store` that can be installed | 
| kubectl maestro install <frameworkName>  |  Installs a framework from the `Maestro App Store` with dependencies | 
| kubectl maestro uninstall <frameworkName> | Uninstalls a framework with all dependencies | 
| kubectl maestro shell |  Lists all available frameworks of which you could get a shell  | 
| kubectl maestro shell <frameworkName> |  gives you a shell - right now just Flink supported | 
| kubectl maestro exec <frameworkName>  <cmd>|  Executes a command for a particular framework - right now just Flink supported | 
| kubectl maestro flink  <cmd>|  Wrapper arround `Flink CLI` that supports all https://ci.apache.org/projects/flink/flink-docs-release-1.7/ops/cli.html commands | 



# Maestro App Store

The Maestro "App Store" is just an experimental feature I added. Run `kubectl maestro install something` and you see a list of available frameworks (looking at our github repo `config/samples` folder for all files with `*-framework.yaml`):

```
maestro-demo $ kubectl maestro install something
something is not a known framework.

Please select the framework to install:

	kafka
	zookeeper
	flink

Syntax:
	kubectl maestro install <frameworkName>

Example:
	kubectl maestro install flink
```

![App Store Install](https://d2ddoduugvun08.cloudfront.net/items/2w0F0n2a1B2R3n1I0D3v/Screen%20Recording%202019-01-24%20at%2007.53%20PM.gif)